### PR TITLE
Fix asserts for Dart 2.0

### DIFF
--- a/lib/binary.dart
+++ b/lib/binary.dart
@@ -119,7 +119,7 @@ int bitChunk(int bits, int left, int size) {
       throw new RangeError.value(size, 'size', 'Out of range. Must be >= 1.');
     }
     return true;
-  });
+  }());
   return (bits >> (left + 1 - size)) & ~(~0 << size);
 }
 
@@ -152,7 +152,7 @@ int fromBits(List<int> bits) {
       throw new ArgumentError.value('Must be non-empty', 'bits');
     }
     return true;
-  });
+  }());
   var result = 0;
   for (var n = 0; n < bits.length; n++) {
     if (bits[n] == 1) {
@@ -409,7 +409,7 @@ class Integral implements Comparable<Integral> {
         throw _rangeError(value, name);
       }
       return true;
-    });
+    }());
   }
 
   /// Returns whether [value] falls in the range of representable by this type.


### PR DESCRIPTION
On run, pub with 2.0 SDK throws 3 of these, one for each assert statement:


```
Unable to spawn isolate: file:///C:/Users/Andrew/AppData/Roaming/Pub/Cache/hosted/pub.dartlang.org/binary-0.1.3/lib/binary.dart:114:10: Error: A value of type '() → dart.core::bool' can't be assigned to a variable of type 'dart.core::bool'.
Try changing the type of the left hand side, or casting the right hand side to 'dart.core::bool'.
  assert(() {
```


Parentheses were need to manually call the anonymous function before passing the result to the assert.